### PR TITLE
Always round hours down in toSMPTE() (fixes #2)

### DIFF
--- a/VideoFrame.js
+++ b/VideoFrame.js
@@ -132,7 +132,7 @@ VideoFrame.prototype.toSMPTE = function(frame) {
 	var fps = this.frameRate;
 	function wrap(n) { return ((n < 10) ? '0' + n : n); }
 	var _hour = ((fps * 60) * 60), _minute = (fps * 60);
-	var _hours = (frameNumber / _hour).toFixed(0);
+	var _hours = Math.floor(frameNumber / _hour).toFixed(0);
 	var _minutes = (Number((frameNumber / _minute).toString().split('.')[0]) % 60);
 	var _seconds = (Number((frameNumber / fps).toString().split('.')[0]) % 60);
 	var SMPTE = (wrap(_hours) + ':' + wrap(_minutes) + ':' + wrap(_seconds) + ':' + wrap(frameNumber % fps));


### PR DESCRIPTION
Credit to @philippede: https://github.com/allensarkisyan/VideoFrame/issues/2#issuecomment-77918912
